### PR TITLE
Fix: null manifest if not using db or protobuf output

### DIFF
--- a/src/main/java/edu/psu/cse/siis/ic3/Ic3Analysis.java
+++ b/src/main/java/edu/psu/cse/siis/ic3/Ic3Analysis.java
@@ -235,11 +235,8 @@ public class Ic3Analysis extends Analysis<Ic3CommandLineArguments> {
   }
 
   protected void prepareManifestFile(Ic3CommandLineArguments commandLineArguments) {
-    if (commandLineArguments.getDb() != null
-        || commandLineArguments.getProtobufDestination() != null) {
       detailedManifest = new ManifestPullParser();
       detailedManifest.loadManifestFile(commandLineArguments.getManifest());
-    }
   }
 
   @Override


### PR DESCRIPTION
In `protected void processResults(Ic3CommandLineArguments commandLineArguments)` method in Ic3Analysis.java file, there is the following statement: System.out.println(detailedManifest.toString());
Obviously in `  protected void prepareManifestFile(Ic3CommandLineArguments commandLineArguments)` if no db file nor protobuf destination is given, we get a null pointer exception for `detailedManifest`.

If one uses IC3 for test purposes and just want to check the standard output, this modification allows it.